### PR TITLE
feat: allow custom fonts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ abstract class CanvasService extends Service {
 
   abstract createCanvas(width: number, height: number): Promise<Canvas>
   abstract loadImage(source: string | URL | Buffer | ArrayBufferLike): Promise<Image>
+  abstract loadFont(source: string | URL | Buffer | ArrayBufferLike): Promise<string>
 
   async render(width: number, height: number, callback: (ctx: CanvasRenderingContext2D) => Awaitable<void>) {
     const canvas = await this.createCanvas(width, height)


### PR DESCRIPTION
Allow the user to load custom fonts like loading images.

绘制文本时使用默认字体比较难看，但同时并没有一个方便的加载字体的方式。添加了个接口用来解决这个问题。目前只传回 id 字符串，不确定这样用好不好。

用法：

```
const font = await ctx.canvas.loadFont("file:///example/url/font.otf")
canvasCtx.font = `50px ${font}`
canvasCtx.fillText("Test", 300, 600)
```